### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-beta-release-publish.yml
+++ b/.github/workflows/npm-beta-release-publish.yml
@@ -3,6 +3,10 @@
 
 name: Publish beta release
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   release:
     types: [prereleased]


### PR DESCRIPTION
Potential fix for [https://github.com/BrowserStackCE/percysync/security/code-scanning/2](https://github.com/BrowserStackCE/percysync/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow involves publishing a package to npm, it requires `contents: read` to access the repository contents and `packages: write` to publish the package. These permissions adhere to the principle of least privilege, ensuring the workflow has only the permissions it needs.

The `permissions` block will be added at the root of the workflow, applying to all jobs. This ensures consistency and avoids redundancy.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
