### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,10 @@
 
 name: Publish release
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   release:
     types: [released]


### PR DESCRIPTION
Potential fix for [https://github.com/BrowserStackCE/percysync/security/code-scanning/1](https://github.com/BrowserStackCE/percysync/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. In this case, the workflow primarily interacts with the repository contents and publishes a package, so it needs `contents: read` and possibly `packages: write` permissions.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`publish-npm`) to limit permissions to that job only. Since the workflow has only one job, adding the `permissions` block at the root level is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
